### PR TITLE
SoapServiceClient doesn't allow runtime binding/channel creation. New constructor perhaps?

### DIFF
--- a/Source/Nelibur/ServiceModel/Clients/SoapServiceClient.cs
+++ b/Source/Nelibur/ServiceModel/Clients/SoapServiceClient.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.ServiceModel;
 using System.ServiceModel.Channels;
+using System.ServiceModel.Description;
 using System.Threading.Tasks;
 using Nelibur.ServiceModel.Contracts;
 using Nelibur.ServiceModel.Services.Headers;
@@ -25,6 +26,28 @@ namespace Nelibur.ServiceModel.Clients
             }
             _channelFactory = new ChannelFactory<ISoapService>(endpointConfigurationName);
         }
+        
+        /// <summary>
+        ///     Create new instance of <see cref="SoapServiceClient" /> .
+        /// </summary>
+        /// <param name="binding">WCF binding.</param>
+        /// <param name="endPointAddress">The endpoint address. e.g.: net.tcp://localhost:9999/service</param>
+        public SoapServiceClient(Binding binding, string endPointAddress)
+        {
+            if (string.IsNullOrWhiteSpace(endPointAddress))
+            {
+                throw Error.ConfigurationError("Invalid endPointAddress: Is null or empty");
+            }
+            if (binding == null)
+            {
+                throw Error.ConfigurationError("Invalid binding: Null");
+            }
+            var epAddress = new EndpointAddress(endPointAddress);
+            var serviceEndpoint = new ServiceEndpoint(ContractDescription.GetContract(typeof(ISoapService)), binding, epAddress);
+            _channelFactory = new ChannelFactory<ISoapService>(serviceEndpoint);
+        }
+        
+        public SoapServiceClient()
 
         public void Delete(object request)
         {

--- a/Source/Nelibur/ServiceModel/Clients/SoapServiceClient.cs
+++ b/Source/Nelibur/ServiceModel/Clients/SoapServiceClient.cs
@@ -46,8 +46,6 @@ namespace Nelibur.ServiceModel.Clients
             var serviceEndpoint = new ServiceEndpoint(ContractDescription.GetContract(typeof(ISoapService)), binding, epAddress);
             _channelFactory = new ChannelFactory<ISoapService>(serviceEndpoint);
         }
-        
-        public SoapServiceClient()
 
         public void Delete(object request)
         {


### PR DESCRIPTION
Hi,
I'm using the library for my project where I have to scan the local area network for computers and discover the wcf services on them, and when there's one I create a channel factory for that service.
Unfortunately the SoapServiceClient class doesn't let you provide a runtime generated endpoint, so I have added it, and I'd like to ask you for your opinion about this change.